### PR TITLE
Make scrobbling endpoint documentation clearer

### DIFF
--- a/docs/src/content/docs/guides/scrobbler.md
+++ b/docs/src/content/docs/guides/scrobbler.md
@@ -21,6 +21,9 @@ If you are not running Koito on an `https://` connection or `localhost`,  the cl
 :::
 
 Then, direct any application you want to scrobble data from to `{your_koito_address}/apis/listenbrainz/1` and provide the api key from the UI as the token.
+:::note
+For MultiScrobbler, set the endpoint to `{your_koito_address}/apis/listenbrainz/1`
+:::
 
 ## Set up a relay
 

--- a/docs/src/content/docs/guides/scrobbler.md
+++ b/docs/src/content/docs/guides/scrobbler.md
@@ -22,7 +22,7 @@ If you are not running Koito on an `https://` connection or `localhost`,  the cl
 
 Then, direct any application you want to scrobble data from to `{your_koito_address}/apis/listenbrainz/1` and provide the api key from the UI as the token.
 :::note
-For Multi-Scrobbler, set the endpoint to `{your_koito_address}/apis/listenbrainz/1`
+For Multi-Scrobbler, set the endpoint to `{your_koito_address}/apis/listenbrainz`
 :::
 
 ## Set up a relay

--- a/docs/src/content/docs/guides/scrobbler.md
+++ b/docs/src/content/docs/guides/scrobbler.md
@@ -22,7 +22,7 @@ If you are not running Koito on an `https://` connection or `localhost`,  the cl
 
 Then, direct any application you want to scrobble data from to `{your_koito_address}/apis/listenbrainz/1` and provide the api key from the UI as the token.
 :::note
-For MultiScrobbler, set the endpoint to `{your_koito_address}/apis/listenbrainz/1`
+For Multi-Scrobbler, set the endpoint to `{your_koito_address}/apis/listenbrainz/1`
 :::
 
 ## Set up a relay


### PR DESCRIPTION
Hey, I just set up multiscrobbler to scrobble to Koito, but it took be 20 minutes to figure out that the configured URL has to be `endpoint/apis/listenbrainz/`- _not_ `endpoint/apis/listenbrainz/1` like it says in the docs. Hopefully this PR makes it clearer? I'm not 100% decided on the wording/formatting, let me know what you think :3