### PR TITLE
fix: embed db migrations

### DIFF
--- a/db/migrations/migrations.go
+++ b/db/migrations/migrations.go
@@ -1,0 +1,6 @@
+package migrations
+
+import "embed"
+
+//go:embed *.sql
+var Files embed.FS

--- a/internal/db/psql/psql.go
+++ b/internal/db/psql/psql.go
@@ -5,10 +5,9 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"path/filepath"
-	"runtime"
 	"time"
 
+	"github.com/gabehf/koito/db/migrations"
 	"github.com/gabehf/koito/internal/cfg"
 	"github.com/gabehf/koito/internal/db"
 	"github.com/gabehf/koito/internal/repository"
@@ -54,13 +53,9 @@ func New() (*Psql, error) {
 		return nil, fmt.Errorf("psql.New: failed to open db for migrations: %w", err)
 	}
 
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		return nil, fmt.Errorf("psql.New: unable to get caller info")
-	}
-	migrationsPath := filepath.Join(filepath.Dir(filename), "..", "..", "..", "db", "migrations")
+	goose.SetBaseFS(migrations.Files)
 
-	if err := goose.Up(sqlDB, migrationsPath); err != nil {
+	if err := goose.Up(sqlDB, "."); err != nil {
 		return nil, fmt.Errorf("psql.New: goose failed: %w", err)
 	}
 	_ = sqlDB.Close()


### PR DESCRIPTION
I've created an [AUR package](https://aur.archlinux.org/packages/koito) for Koito :).

I was getting the following error after setting it up and running the service:
```
ERR > Engine: Failed to connect to database; retrying in 5 seconds | error="psql.New: goose failed: github.com/gabehf/koito/db/migrations directory does not exist"
```

Embedding the db migrations fixed it.

I guess runtime.Caller won't work properly once things are moved outside the source tree.