### PR TITLE
Add support for building and pushing ARM-compatible Docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -83,6 +83,7 @@ jobs:
             gabehf/koito:${{ env.KOITO_VERSION }}
           build-args: |
             KOITO_VERSION=${{ env.KOITO_VERSION }}
+          platforms: linux/amd64,linux/arm64     
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2


### PR DESCRIPTION
This should be all that's needed to build and push an ARM-compatible image, as requested in [#46](https://github.com/gabehf/Koito/issues/46).
(I couldn't test it properly as I don't have access to the env variables)

I build it locally using `docker buildx build -f Dockerfile --platform "linux/arm64" --tag benjaminjonard/my_repo --push .` and it's running without issue on my ARM based server.