### PR TITLE
set name/short_name in site webmanifest to koito

### DIFF
--- a/client/public/site.webmanifest
+++ b/client/public/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
+  "name": "Koito",
+  "short_name": "Koito",
   "icons": [
     {
       "src": "/web-app-manifest-192x192.png",


### PR DESCRIPTION
I noticed when installing the koito pwa onto my phone that its name was 'mywebsite', this sets that back to 'koito'