### PR TITLE
fix: correctly cycle tracks in backfill

### DIFF
--- a/internal/catalog/duration.go
+++ b/internal/catalog/duration.go
@@ -21,6 +21,7 @@ func BackfillTrackDurationsFromMusicBrainz(
 	var from int32 = 0
 
 	for {
+		l.Debug().Int32("ID", from).Msg("Fetching tracks to backfill from ID")
 		tracks, err := store.GetTracksWithNoDurationButHaveMbzID(ctx, from)
 		if err != nil {
 			return fmt.Errorf("BackfillTrackDurationsFromMusicBrainz: failed to fetch tracks for duration backfill: %w", err)

--- a/internal/catalog/duration_test.go
+++ b/internal/catalog/duration_test.go
@@ -1,0 +1,36 @@
+package catalog_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gabehf/koito/internal/catalog"
+	"github.com/gabehf/koito/internal/mbz"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackfillDuration(t *testing.T) {
+	setupTestDataWithMbzIDs(t)
+
+	ctx := context.Background()
+	mbzc := &mbz.MbzMockCaller{
+		Artists:  mbzArtistData,
+		Releases: mbzReleaseData,
+		Tracks:   mbzTrackData,
+	}
+
+	var err error
+
+	err = catalog.BackfillTrackDurationsFromMusicBrainz(context.Background(), store, &mbz.MbzErrorCaller{})
+	assert.NoError(t, err)
+
+	err = catalog.BackfillTrackDurationsFromMusicBrainz(ctx, store, mbzc)
+	assert.NoError(t, err)
+
+	count, err := store.Count(ctx, `
+		SELECT COUNT(*) FROM tracks_with_title WHERE title = $1 AND duration > 0
+		`, "Tokyo Calling")
+	require.NoError(t, err)
+	assert.Equal(t, 1, count, "track was not updated with duration")
+}

--- a/internal/db/psql/track.go
+++ b/internal/db/psql/track.go
@@ -380,7 +380,7 @@ func (d *Psql) SetPrimaryTrackArtist(ctx context.Context, id int32, artistId int
 func (d *Psql) GetTracksWithNoDurationButHaveMbzID(ctx context.Context, from int32) ([]*models.Track, error) {
 	results, err := d.q.GetTracksWithNoDurationButHaveMbzID(ctx, repository.GetTracksWithNoDurationButHaveMbzIDParams{
 		Limit: 20,
-		ID:    0,
+		ID:    from,
 	})
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil


### PR DESCRIPTION
Fixes duration backfill looping on 404 or other error from MusicBrainz.

Also adds a test for duration backfill logic which I should have done earlier...