### PR TITLE
fix: invalid json response when login gate is disabled

### DIFF
--- a/engine/long_test.go
+++ b/engine/long_test.go
@@ -367,6 +367,16 @@ func TestLoginGate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 204, resp.StatusCode)
 
+	req, err = http.NewRequest("GET", host()+"/apis/web/v1/artist?id=3", nil)
+	require.NoError(t, err)
+	resp, err = http.DefaultClient.Do(req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+	var artist models.Artist
+	err = json.NewDecoder(resp.Body).Decode(&artist)
+	require.NoError(t, err)
+	assert.Equal(t, "ネクライトーキー", artist.Name)
+
 	cfg.SetLoginGate(true)
 
 	req, err = http.NewRequest("GET", host()+"/apis/web/v1/artist?id=3", nil)
@@ -382,6 +392,9 @@ func TestLoginGate(t *testing.T) {
 	resp, err = http.DefaultClient.Do(req)
 	assert.NoError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
+	err = json.NewDecoder(resp.Body).Decode(&artist)
+	require.NoError(t, err)
+	assert.Equal(t, "ネクライトーキー", artist.Name)
 
 	cfg.SetLoginGate(false)
 

--- a/engine/middleware/authenticate.go
+++ b/engine/middleware/authenticate.go
@@ -62,6 +62,7 @@ func Authenticate(store db.DB, mode AuthMode) func(http.Handler) http.Handler {
 					}
 				} else {
 					next.ServeHTTP(w, r)
+					return
 				}
 			}
 
@@ -76,10 +77,8 @@ func Authenticate(store db.DB, mode AuthMode) func(http.Handler) http.Handler {
 				return
 			}
 
-			if user != nil {
-				ctx = context.WithValue(ctx, UserContextKey, user)
-				r = r.WithContext(ctx)
-			}
+			ctx = context.WithValue(ctx, UserContextKey, user)
+			r = r.WithContext(ctx)
 
 			next.ServeHTTP(w, r)
 		})


### PR DESCRIPTION
Last PR had a bug that my tests didn't catch because I guess json.NewDecoder() works differently than I expected.