### PR TITLE
Fix artist name parsing for Last.fm imports

### DIFF
--- a/internal/importer/lastfm.go
+++ b/internal/importer/lastfm.go
@@ -108,7 +108,6 @@ func ImportLastFMFile(ctx context.Context, store db.DB, mbzc mbz.MusicBrainzCall
 			opts := catalog.SubmitListenOpts{
 				MbzCaller:          mbzc,
 				Artist:             track.Artist.Text,
-				ArtistNames:        []string{track.Artist.Text},
 				ArtistMbzIDs:       []uuid.UUID{artistMbzID},
 				TrackTitle:         track.Name,
 				RecordingMbzID:     trackMbzID,


### PR DESCRIPTION
Artist name parsing (for "feat." in the artist name) is skipped when the `ArtistNames` field is populated (https://github.com/gabehf/Koito/blob/0ec7b458ccf29bed07e5cd53ac407c117a29f2b2/internal/catalog/associate_artists.go#L55-L62).

Last.fm doesn't support multiple artists so this parsing is always going to be needed here.

NB: artist parsing is going to be skipped for any source that populates `ArtistNames` in this way, e.g. Multi-Scrobbler with Last.fm as a source will have the same issue. Might be helpful to change the association step to do parsing if `ArtistNames` contains a single value that matches `Artist`.

Possibly related: #59