### PR TITLE
Include `listen_type` in the coalescing key used during listen submission

### DIFF
--- a/engine/handlers/lbz_submit_listen.go
+++ b/engine/handlers/lbz_submit_listen.go
@@ -220,7 +220,7 @@ func LbzSubmitListenHandler(store db.DB, mbzc mbz.MusicBrainzCaller) func(w http
 				SkipSaveListen:     req.ListenType == ListenTypePlayingNow,
 			}
 
-			_, err, shared := sfGroup.Do(buildCaolescingKey(payload, req.ListenType), func() (interface{}, error) {
+			_, err, shared := sfGroup.Do(buildCoalescingKey(payload, req.ListenType), func() (interface{}, error) {
 				return 0, catalog.SubmitListen(r.Context(), store, opts)
 			})
 			if shared {
@@ -308,6 +308,6 @@ func doLbzRelay(requestBytes []byte, l *zerolog.Logger) {
 	}
 }
 
-func buildCaolescingKey(p LbzSubmitListenPayload, listenType LbzListenType) string {
+func buildCoalescingKey(p LbzSubmitListenPayload, listenType LbzListenType) string {
 	return fmt.Sprintf("%s:%s:%s:%s", listenType, p.TrackMeta.ArtistName, p.TrackMeta.TrackName, p.TrackMeta.ReleaseName)
 }

--- a/engine/handlers/lbz_submit_listen.go
+++ b/engine/handlers/lbz_submit_listen.go
@@ -220,7 +220,7 @@ func LbzSubmitListenHandler(store db.DB, mbzc mbz.MusicBrainzCaller) func(w http
 				SkipSaveListen:     req.ListenType == ListenTypePlayingNow,
 			}
 
-			_, err, shared := sfGroup.Do(buildCaolescingKey(payload), func() (interface{}, error) {
+			_, err, shared := sfGroup.Do(buildCaolescingKey(payload, req.ListenType), func() (interface{}, error) {
 				return 0, catalog.SubmitListen(r.Context(), store, opts)
 			})
 			if shared {
@@ -308,13 +308,6 @@ func doLbzRelay(requestBytes []byte, l *zerolog.Logger) {
 	}
 }
 
-func buildCaolescingKey(p LbzSubmitListenPayload) string {
-	// the key not including the listen_type introduces the very rare possibility of a playing_now
-	// request taking precedence over a single, meaning that a listen will not be logged when it
-	// should, however that would require a playing_now request to fire a few seconds before a 'single'
-	// of the same track, which should never happen outside of misbehaving clients
-	//
-	// this could be fixed by restructuring the database inserts for idempotency, which would
-	// eliminate the need to coalesce responses, however i'm not gonna do that right now
-	return fmt.Sprintf("%s:%s:%s", p.TrackMeta.ArtistName, p.TrackMeta.TrackName, p.TrackMeta.ReleaseName)
+func buildCaolescingKey(p LbzSubmitListenPayload, listenType LbzListenType) string {
+	return fmt.Sprintf("%s:%s:%s:%s", listenType, p.TrackMeta.ArtistName, p.TrackMeta.TrackName, p.TrackMeta.ReleaseName)
 }

--- a/engine/handlers/lbz_submit_listen.go
+++ b/engine/handlers/lbz_submit_listen.go
@@ -227,7 +227,7 @@ func LbzSubmitListenHandler(store submitListenHandlerStore, mbzc mbz.MusicBrainz
 				SkipSaveListen:     req.ListenType == ListenTypePlayingNow,
 			}
 
-			_, err, shared := sfGroup.Do(buildCaolescingKey(payload), func() (interface{}, error) {
+			_, err, shared := sfGroup.Do(buildCaolescingKey(payload, req.ListenType), func() (interface{}, error) {
 				return 0, catalog.SubmitListen(r.Context(), store, opts)
 			})
 			if shared {
@@ -315,13 +315,6 @@ func doLbzRelay(requestBytes []byte, l *zerolog.Logger) {
 	}
 }
 
-func buildCaolescingKey(p LbzSubmitListenPayload) string {
-	// the key not including the listen_type introduces the very rare possibility of a playing_now
-	// request taking precedence over a single, meaning that a listen will not be logged when it
-	// should, however that would require a playing_now request to fire a few seconds before a 'single'
-	// of the same track, which should never happen outside of misbehaving clients
-	//
-	// this could be fixed by restructuring the database inserts for idempotency, which would
-	// eliminate the need to coalesce responses, however i'm not gonna do that right now
-	return fmt.Sprintf("%s:%s:%s", p.TrackMeta.ArtistName, p.TrackMeta.TrackName, p.TrackMeta.ReleaseName)
+func buildCaolescingKey(p LbzSubmitListenPayload, listenType LbzListenType) string {
+	return fmt.Sprintf("%s:%s:%s:%s", listenType, p.TrackMeta.ArtistName, p.TrackMeta.TrackName, p.TrackMeta.ReleaseName)
 }

--- a/engine/handlers/lbz_submit_listen.go
+++ b/engine/handlers/lbz_submit_listen.go
@@ -227,7 +227,7 @@ func LbzSubmitListenHandler(store submitListenHandlerStore, mbzc mbz.MusicBrainz
 				SkipSaveListen:     req.ListenType == ListenTypePlayingNow,
 			}
 
-			_, err, shared := sfGroup.Do(buildCaolescingKey(payload, req.ListenType), func() (interface{}, error) {
+			_, err, shared := sfGroup.Do(buildCoalescingKey(payload, req.ListenType), func() (interface{}, error) {
 				return 0, catalog.SubmitListen(r.Context(), store, opts)
 			})
 			if shared {
@@ -315,6 +315,6 @@ func doLbzRelay(requestBytes []byte, l *zerolog.Logger) {
 	}
 }
 
-func buildCaolescingKey(p LbzSubmitListenPayload, listenType LbzListenType) string {
+func buildCoalescingKey(p LbzSubmitListenPayload, listenType LbzListenType) string {
 	return fmt.Sprintf("%s:%s:%s:%s", listenType, p.TrackMeta.ArtistName, p.TrackMeta.TrackName, p.TrackMeta.ReleaseName)
 }


### PR DESCRIPTION
I have a [multi-scrobbler](https://github.com/FoxxMD/multi-scrobbler) instance that is connected to Koito, but found that Koito was frequently failing to save listens. The 'now playing' entry would be visible while the track was active, but the actual listen would not be saved. I believe it is due to the case described in the `buildCoalescingKey` function comment:

> the key not including the listen_type introduces the very rare possibility of a playing_now request taking precedence over a single, meaning that a listen will not be logged when it should

The comment mentions that this should be rare, but at one point when I counted I had lost up to 30% of listens. Any reason not to include the `listen_type` in the coalescing key? 

I've been using this branch for a few days and have not had any dropped listens.