### PR TITLE
Fix artist images: filter Last.fm placeholder, reorder providers

### DIFF
--- a/internal/catalog/images.go
+++ b/internal/catalog/images.go
@@ -298,7 +298,7 @@ func FetchMissingArtistImages(ctx context.Context, store db.DB) error {
 				Msg("FetchMissingArtistImages: Attempting to fetch missing artist image")
 
 			var aliases []string
-			if aliasrow, err := store.GetAllArtistAliases(ctx, artist.ID); err != nil {
+			if aliasrow, err := store.GetAllArtistAliases(ctx, artist.ID); err == nil {
 				aliases = utils.FlattenAliases(aliasrow)
 			} else {
 				aliases = []string{artist.Name}

--- a/internal/images/imagesrc.go
+++ b/internal/images/imagesrc.go
@@ -83,6 +83,16 @@ func GetArtistImage(ctx context.Context, opts ArtistImageOpts) (string, error) {
 	} else {
 		l.Debug().Msg("GetArtistImage: Subsonic image fetching is disabled")
 	}
+	if imgsrc.deezerEnabled {
+		img, err := imgsrc.deezerC.GetArtistImages(ctx, opts.Aliases)
+		if err != nil {
+			l.Debug().Err(err).Msg("GetArtistImage: Could not find artist image from Deezer")
+		} else if img != "" {
+			return img, nil
+		}
+	} else {
+		l.Debug().Msg("GetArtistImage: Deezer image fetching is disabled")
+	}
 	if imgsrc.lastfmEnabled {
 		img, err := imgsrc.lastfmC.GetArtistImage(ctx, opts.MBID, opts.Aliases[0])
 		if err != nil {
@@ -92,17 +102,6 @@ func GetArtistImage(ctx context.Context, opts ArtistImageOpts) (string, error) {
 		}
 	} else {
 		l.Debug().Msg("GetArtistImage: LastFM image fetching is disabled")
-	}
-	if imgsrc.deezerEnabled {
-		img, err := imgsrc.deezerC.GetArtistImages(ctx, opts.Aliases)
-		if err != nil {
-			l.Debug().Err(err).Msg("GetArtistImage: Could not find artist image from Deezer")
-			return "", err
-		} else if img != "" {
-			return img, nil
-		}
-	} else {
-		l.Debug().Msg("GetArtistImage: Deezer image fetching is disabled")
 	}
 	l.Warn().Msg("GetArtistImage: No image providers are enabled")
 	return "", nil

--- a/internal/images/lastfm.go
+++ b/internal/images/lastfm.go
@@ -127,6 +127,10 @@ func (c *LastFMClient) getEntity(ctx context.Context, params url.Values, result 
 	return nil
 }
 
+// lastFMPlaceholderHash is the hash of Last.fm's generic "no artist image" placeholder.
+// Last.fm stopped serving real artist images years ago and returns this for nearly every artist.
+const lastFMPlaceholderHash = "2a96cbd8b46e442fc41c2b86b821562f"
+
 // selectBestImage picks the largest available image from the LastFM slice
 func (c *LastFMClient) selectBestImage(images []lastFMImage) string {
 	// Rank preference: mega > extralarge > large > medium > small
@@ -135,7 +139,7 @@ func (c *LastFMClient) selectBestImage(images []lastFMImage) string {
 
 	imgMap := make(map[string]string)
 	for _, img := range images {
-		if img.URL != "" {
+		if img.URL != "" && !strings.Contains(img.URL, lastFMPlaceholderHash) {
 			imgMap[img.Size] = img.URL
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes three bugs causing all artist images to display as the same Last.fm generic placeholder.

**Bug 1 — Last.fm placeholder not filtered** (`internal/images/lastfm.go`)
Last.fm removed real artist images from their API in [May 2019](https://github.com/pylast/pylast/issues/304), citing ToS Section 5.1.8. Every artist query now returns the same placeholder (hash `2a96cbd8b46e442fc41c2b86b821562f`). Added a filter in `selectBestImage` to reject URLs containing this known placeholder hash. This is the same approach [Navidrome uses](https://github.com/navidrome/navidrome/commit/353aff2c8).

**Bug 2 — Provider order** (`internal/images/imagesrc.go`)
`GetArtistImage` checked Last.fm before Deezer. Since Last.fm "succeeded" with the placeholder URL, Deezer was never reached. Swapped order so Deezer (which returns real artist photos) is tried first.

**Bug 3 — Inverted if/else in backfill** (`internal/catalog/images.go`)
`FetchMissingArtistImages` had the `if err != nil` / `else` branches swapped — aliases were used on error, and the bare artist name was used on success. Fixed to `err == nil`.

## Test plan
- [ ] `go build ./...` compiles
- [ ] `go test ./...` passes
- [ ] Manual: clear stale placeholder images, restart, verify real Deezer artist images appear
- [ ] Verify album images still work (no change to album provider order)

🤖 Generated with [Claude Code](https://claude.com/claude-code)