### PR TITLE
Fix: suppress spurious error log when Authorization header is absent

### DIFF
--- a/engine/middleware/authenticate.go
+++ b/engine/middleware/authenticate.go
@@ -133,6 +133,10 @@ func validateAPIKey(ctx context.Context, store db.DB, r *http.Request) (*models.
 	l.Debug().Msg("ValidateApiKey: Checking if user is already authenticated")
 
 	authH := r.Header.Get("Authorization")
+	if authH == "" {
+		return nil, nil // no header present, not an error
+	}
+
 	var token string
 	if strings.HasPrefix(strings.ToLower(authH), "token ") {
 		token = strings.TrimSpace(authH[6:]) // strip "Token "


### PR DESCRIPTION
Fix validateAPIKey logging error when Authorization header is absent

When an unauthenticated request hits an endpoint using AuthModeSessionOrAPIKey (e.g. GET /user/me, called on every page load), the server would log an error even though no malformed header was sent:
ERR > ValidateApiKey: Authorization header must be formatted 'Token {token}'
ERR > authentication failed | error="authorization header is invalid"

Root cause
In validateAPIKey, a missing Authorization header (empty string) fell into the same else branch as a malformed one, triggering an Error log. The two cases were not distinguished.

Fix
Return nil, nil early when the header is absent. The error log now only fires when a header is present but incorrectly formatted, which is the genuinely unexpected case. The request is still correctly rejected with 401.

Closes #242