### PR TITLE
fix: don't treat tracks with similar title as the same track

### DIFF
--- a/internal/catalog/associate_track.go
+++ b/internal/catalog/associate_track.go
@@ -102,8 +102,10 @@ func matchTrackByTrackInfo(ctx context.Context, d db.TrackStore, opts AssociateT
 					ArtistIDs: opts.ArtistIDs,
 				})
 				if err == nil {
-					l.Debug().Msgf("Track '%s' found by MusicBrainz title, release and artist match", opts.TrackName)
-					return track, nil
+					if track.MbzID == nil || *track.MbzID == uuid.Nil || *track.MbzID == opts.TrackMbzID {
+						l.Debug().Msgf("Track '%s' found by MusicBrainz title, release and artist match", opts.TrackName)
+						return track, nil
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Description

Some of the old albums have both mono and stereo of same recordings, or just different remixes, then it's a different recording happens to share the same canonical title (e.g. Aretha Frankin has "Respect" both "Respect (stereo version)" in the same album "I never Loved a Man the Way I Love You" reissue, both of them resolve to "Respect" on MusicBrainz).

This PR only tally count if they share the same track_id, or make sure they goes into the db as different ones.

## Related Issue(s)
N/A

## Type of Change
- [ √] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] Unit Tests
- [√ ] Manual Testing (please describe steps)

## Checklist
- [√ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [√ ] I have ensured my changes generate no new warnings

## AI/LLM Usage
<!-- If no AI/LLMs were used, you may skip this portion of the template -->
- [ ] I disclose that XX% of the code in this PR is written by an LLM. (please estimate)
- [ ] I fully understand all changes made by LLM-generated code.
- [ ] I have not and will not use an LLM to write any part of this PR description or PR comments.

## Screenshots (if applicable)
<img width="934" height="276" alt="image" src="https://github.com/user-attachments/assets/2ac78057-c814-4784-8740-f9bab4965970" />


