### PR TITLE
fix: improve ui when there is no data

### DIFF
--- a/client/app/components/ArtistAlbums.tsx
+++ b/client/app/components/ArtistAlbums.tsx
@@ -38,6 +38,7 @@ export default function ArtistAlbums({ artistId, name }: Props) {
     <div>
       <h3>Albums featuring {name}</h3>
       <div className="flex flex-wrap gap-8">
+        {data.items.length < 1 && "Nothing to show"}
         {data.items.map((item) => (
           <Link
             to={`/album/${item.item.id}`}

--- a/client/app/components/LastPlays.tsx
+++ b/client/app/components/LastPlays.tsx
@@ -90,6 +90,7 @@ export default function LastPlays(props: Props) {
       <h3 className="hover:underline">
         <Link to={`/listens?period=all_time${params}`}>{header}</Link>
       </h3>
+      {listens.length < 1 && "Nothing to show"}
       <table className="-ml-4">
         <tbody>
           {props.showNowPlaying && npData && npData.currently_playing && (

--- a/client/app/routes/MediaItems/Artist.tsx
+++ b/client/app/routes/MediaItems/Artist.tsx
@@ -52,7 +52,7 @@ export default function Artist() {
       }}
       subContent={
         <div className="flex flex-col gap-2 items-start">
-          {artist.listen_count && (
+          {artist.listen_count > 0 && (
             <p>
               {artist.listen_count} play{artist.listen_count > 1 ? "s" : ""}
             </p>

--- a/client/app/routes/MediaItems/MediaLayout.tsx
+++ b/client/app/routes/MediaItems/MediaLayout.tsx
@@ -102,7 +102,7 @@ export default function MediaLayout(props: Props) {
                 {props.title}
                 <span className="text-xl font-medium text-(--color-fg-secondary)">
                   {" "}
-                  #{props.rank}
+                  {props.rank !== 0 && "#" + props.rank}
                 </span>
               </h1>
             </div>


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes and the motivation behind them. -->
- Adds "Nothing to show" when there is no data for Last Played and Artist Album components
- Fixes conditional rendering for play count in artist pages with no plays
- Adds conditional rendering for item rank when item has no plays

## Related Issue(s)
<!-- Link to the issue this PR addresses (e.g., Fixes #123) -->
n/a 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] Unit Tests
- [ ] Manual Testing (please describe steps)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have ensured my changes generate no new warnings

## AI/LLM Usage
<!-- If no AI/LLMs were used, you may skip this portion of the template -->
- [ ] I disclose that XX% of the code in this PR is written by an LLM. (please estimate)
- [ ] I fully understand all changes made by LLM-generated code.
- [ ] I have not and will not use an LLM to write any part of this PR description or PR comments.

## Screenshots (if applicable)
<!-- Add screenshots or screen recordings to help the reviewer understand the UI changes. -->

