### PR TITLE
fix: only show primary artist on album page

### DIFF
--- a/client/app/routes/MediaItems/Album.tsx
+++ b/client/app/routes/MediaItems/Album.tsx
@@ -46,18 +46,21 @@ export default function Album() {
       }}
       subContent={
         <div className="flex flex-col gap-2 items-start">
-          {album.artists.length > 0 && (
+          {album.artists.length > 0 && !album.is_various_artists && (
             <p>
-              {album.artists.map((artist, i) => (
-                <span key={artist.id}>
-                  {i > 0 && ", "}
-                  <Link className="hover:underline" to={`/artist/${artist.id}`}>
-                    {artist.name}
+              {
+                <span key={album.artists[0].id}>
+                  <Link
+                    className="hover:underline"
+                    to={`/artist/${album.artists[0].id}`}
+                  >
+                    {album.artists[0].name}
                   </Link>
                 </span>
-              ))}
+              }
             </p>
           )}
+          {album.is_various_artists && <p>Various Artists</p>}
           {album.listen_count !== 0 && (
             <p>
               {album.listen_count} play{album.listen_count > 1 ? "s" : ""}
@@ -91,4 +94,3 @@ export default function Album() {
     </MediaLayout>
   );
 }
-


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes and the motivation behind them. -->
Alters the artist list on album pages to only show the primary artist on albums to avoid excessively long lists on albums with lots of featured artists. Also adds a non-clickable "Various Artists" for albums with no primary artist (compilation albums).

## Related Issue(s)
<!-- Link to the issue this PR addresses (e.g., Fixes #123) -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] Unit Tests
- [ ] Manual Testing (please describe steps)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have ensured my changes generate no new warnings

## AI/LLM Usage
<!-- If no AI/LLMs were used, you may skip this portion of the template -->
- [ ] I disclose that XX% of the code in this PR is written by an LLM. (please estimate)
- [ ] I fully understand all changes made by LLM-generated code.
- [ ] I have not and will not use an LLM to write any part of this PR description or PR comments.
n/a 

## Screenshots (if applicable)
<!-- Add screenshots or screen recordings to help the reviewer understand the UI changes. -->

