### PR TITLE
fix: add a permissions check for config dir

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -75,6 +75,13 @@ func Run(
 			return err
 		}
 	}
+	f, err := os.CreateTemp(cfg.ConfigDir(), ".koito_perm_check_*")
+	if err != nil {
+		l.Fatal().Err(err).Msg("Engine: Config directory is not writable")
+		return err
+	}
+	f.Close()
+	os.Remove(f.Name())
 	l.Info().Msgf("Engine: Using config directory: %s", cfg.ConfigDir())
 
 	l.Debug().Msgf("Engine: Checking import directory: %s", path.Join(cfg.ConfigDir(), "import"))


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes and the motivation behind them. -->
Adds a simple permission check to ensure the config directory being used is writable. The program still fails to start in the current state when the config directory is not writable, but this PR makes the error more clear.

## Related Issue(s)
<!-- Link to the issue this PR addresses (e.g., Fixes #123) -->
n/a 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] Unit Tests
- [x] Manual Testing (please describe steps)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have ensured my changes generate no new warnings

## AI/LLM Usage
<!-- If no AI/LLMs were used, you may skip this portion of the template -->
- [x] I disclose that 100% of the code in this PR is written by an LLM. (please estimate)
- [x] I fully understand all changes made by LLM-generated code.
- [x] I have not and will not use an LLM to write any part of this PR description or PR comments.

## Screenshots (if applicable)
<!-- Add screenshots or screen recordings to help the reviewer understand the UI changes. -->

