### PR TITLE
feat: reset password

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -12,11 +12,14 @@ import (
 var Version = "dev"
 
 func main() {
-	if err := engine.Run(
-		readEnvOrFile,
-		os.Stdout,
-		Version,
-	); err != nil {
+	if len(os.Args) > 1 && os.Args[1] == "reset-password" {
+		if err := engine.ResetPassword(readEnvOrFile, os.Stdout, Version); err != nil {
+			fmt.Fprintf(os.Stderr, "%s\n", err)
+			os.Exit(1)
+		}
+		return
+	}
+	if err := engine.Run(readEnvOrFile, os.Stdout, Version); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -33,19 +33,12 @@ import (
 	"github.com/rs/zerolog"
 )
 
-func Run(
-	getenv func(string) string,
-	w io.Writer,
-	version string,
-) error {
-	err := cfg.Load(getenv, version)
-	if err != nil {
-		log.Fatalf("Engine: failed to load configuration: %v", err)
+func initLogger(getenv func(string) string, version string, w io.Writer) (*zerolog.Logger, context.Context, error) {
+	if err := cfg.Load(getenv, version); err != nil {
+		return nil, nil, fmt.Errorf("failed to load configuration: %w", err)
 	}
 
 	l := logger.Get()
-
-	l.Debug().Msg("Engine: Starting application initialization")
 
 	if cfg.StructuredLogging() {
 		l.Debug().Msg("Engine: Enabling structured logging")
@@ -55,15 +48,51 @@ func Run(
 		*l = l.Output(zerolog.ConsoleWriter{
 			Out:        w,
 			TimeFormat: time.RFC3339,
-			FormatMessage: func(i interface{}) string {
+			FormatMessage: func(i any) string {
 				return fmt.Sprintf("\u001b[30;1m>\u001b[0m %s |", i)
 			},
 		})
 	}
 
 	ctx := logger.NewContext(l)
-
 	l.Info().Msgf("Koito %s", version)
+	return l, ctx, nil
+}
+
+func connectDB(l *zerolog.Logger) db.DB {
+	l.Debug().Msg("Engine: Initializing database connection")
+	if cfg.SqliteEnabled() {
+		l.Info().Msg("Engine: Using SQLite database driver")
+		s, err := sqlite.New()
+		for err != nil {
+			l.Error().Err(err).Msg("Engine: Failed to connect to database; retrying in 5 seconds")
+			time.Sleep(5 * time.Second)
+			s, err = sqlite.New()
+		}
+		l.Info().Msg("Engine: Database connection established")
+		return s
+	}
+	p, err := psql.New()
+	for err != nil {
+		l.Error().Err(err).Msg("Engine: Failed to connect to database; retrying in 5 seconds")
+		time.Sleep(5 * time.Second)
+		p, err = psql.New()
+	}
+	l.Info().Msg("Engine: Database connection established")
+	return p
+}
+
+func Run(
+	getenv func(string) string,
+	w io.Writer,
+	version string,
+) error {
+	l, ctx, err := initLogger(getenv, version, w)
+	if err != nil {
+		log.Fatalf("Engine: %v", err)
+	}
+
+	l.Debug().Msg("Engine: Starting application initialization")
 
 	l.Debug().Msgf("Engine: Checking config directory: %s", cfg.ConfigDir())
 	_, err = os.Stat(cfg.ConfigDir())
@@ -97,30 +126,8 @@ func Run(
 		l.Info().Msg("Engine: Migration complete; proceeding with SQLite")
 	}
 
-	l.Debug().Msg("Engine: Initializing database connection")
-	var store db.DB
-	if cfg.SqliteEnabled() {
-		l.Info().Msg("Engine: Using SQLite database driver")
-		var s *sqlite.Sqlite
-		s, err = sqlite.New()
-		for err != nil {
-			l.Error().Err(err).Msg("Engine: Failed to connect to database; retrying in 5 seconds")
-			time.Sleep(5 * time.Second)
-			s, err = sqlite.New()
-		}
-		store = s
-	} else {
-		var p *psql.Psql
-		p, err = psql.New()
-		for err != nil {
-			l.Error().Err(err).Msg("Engine: Failed to connect to database; retrying in 5 seconds")
-			time.Sleep(5 * time.Second)
-			p, err = psql.New()
-		}
-		store = p
-	}
+	store := connectDB(l)
 	defer store.Close(ctx)
-	l.Info().Msg("Engine: Database connection established")
 
 	l.Debug().Msg("Engine: Checking for default user")
 	userCount, _ := store.CountUsers(ctx)

--- a/engine/reset_password.go
+++ b/engine/reset_password.go
@@ -1,0 +1,43 @@
+package engine
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/gabehf/koito/internal/db"
+	"github.com/gabehf/koito/internal/utils"
+)
+
+func ResetPassword(getenv func(string) string, w io.Writer, version string) error {
+	l, ctx, err := initLogger(getenv, version, w)
+	if err != nil {
+		return fmt.Errorf("ResetPassword: %w", err)
+	}
+
+	store := connectDB(l)
+	defer store.Close(ctx)
+
+	user, err := store.GetAdminUser(ctx)
+	if err != nil {
+		return fmt.Errorf("ResetPassword: failed to get admin user: %w", err)
+	}
+	if user == nil {
+		return errors.New("ResetPassword: no admin user found")
+	}
+
+	newPassword, err := utils.GenerateRandomString(16)
+	if err != nil {
+		return fmt.Errorf("ResetPassword: failed to generate password: %w", err)
+	}
+
+	if err := store.UpdateUser(ctx, db.UpdateUserOpts{
+		ID:       user.ID,
+		Password: newPassword,
+	}); err != nil {
+		return fmt.Errorf("ResetPassword: failed to update password: %w", err)
+	}
+
+	l.Info().Msgf("Password for '%s' has been reset. New password: %s", user.Username, newPassword)
+	return nil
+}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -82,6 +82,7 @@ type UserStore interface {
 	GetUserBySession(ctx context.Context, sessionId uuid.UUID) (*models.User, error)
 	GetUserByUsername(ctx context.Context, username string) (*models.User, error)
 	GetUserByApiKey(ctx context.Context, key string) (*models.User, error)
+	GetAdminUser(ctx context.Context) (*models.User, error)
 	GetApiKeysByUserID(ctx context.Context, id int32) ([]models.ApiKey, error)
 	SaveUser(ctx context.Context, opts SaveUserOpts) (*models.User, error)
 	SaveApiKey(ctx context.Context, opts SaveApiKeyOpts) (*models.ApiKey, error)

--- a/internal/db/psql/user.go
+++ b/internal/db/psql/user.go
@@ -48,6 +48,10 @@ func (d *Psql) GetUserByApiKey(ctx context.Context, key string) (*models.User, e
 	}, nil
 }
 
+func (d *Psql) GetAdminUser(ctx context.Context) (*models.User, error) {
+	return nil, errors.New("GetAdminUser: not supported for postgres")
+}
+
 func (d *Psql) SaveUser(ctx context.Context, opts db.SaveUserOpts) (*models.User, error) {
 	l := logger.FromContext(ctx)
 	err := ValidateUsername(opts.Username)

--- a/internal/db/sqlite/user.go
+++ b/internal/db/sqlite/user.go
@@ -62,6 +62,21 @@ func (s *Sqlite) GetUserByUsername(ctx context.Context, username string) (*model
 	return &u, nil
 }
 
+func (s *Sqlite) GetAdminUser(ctx context.Context) (*models.User, error) {
+	var u models.User
+	var role string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT id, username, role, password FROM users WHERE role = 'admin' LIMIT 1`,
+	).Scan(&u.ID, &u.Username, &role, &u.Password)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, nil
+	} else if err != nil {
+		return nil, fmt.Errorf("GetAdminUser: %w", err)
+	}
+	u.Role = models.UserRole(role)
+	return &u, nil
+}
+
 func (s *Sqlite) GetUserByApiKey(ctx context.Context, key string) (*models.User, error) {
 	var u models.User
 	var role string


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes and the motivation behind them. -->
Adds a reset-password command that can be run with `./koito reset-password`, which will generate a new random password and output it to stdout so that if a user forgets their password there is an easy way to recover their account instead of fishing around in the db file.

Only works with SQLite since PostgreSQL support will be deprecated soonish.

Also does some refactoring to engine.Run()

## Related Issue(s)
<!-- Link to the issue this PR addresses (e.g., Fixes #123) -->
#39

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] Unit Tests
- [x] Manual Testing (please describe steps)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have ensured my changes generate no new warnings

## AI/LLM Usage
<!-- If no AI/LLMs were used, you may skip this portion of the template -->
- [x] I disclose that 90% of the code in this PR is written by an LLM. (please estimate)
- [x] I fully understand all changes made by LLM-generated code.
- [x] I have not and will not use an LLM to write any part of this PR description or PR comments.

## Screenshots (if applicable)
<!-- Add screenshots or screen recordings to help the reviewer understand the UI changes. -->

