### PR TITLE
fix: distinguish tracks by their release_ids

### DIFF
--- a/db/queries/track.sql
+++ b/db/queries/track.sql
@@ -25,7 +25,7 @@ WHERE t.id = $1 LIMIT 1;
 
 -- name: GetTrackByMbzID :one
 SELECT * FROM tracks_with_title
-WHERE musicbrainz_id = $1 LIMIT 1;
+WHERE musicbrainz_id = $1 AND release_id = $2 LIMIT 1;
 
 -- name: GetAllTracksFromArtist :many
 SELECT t.*

--- a/internal/catalog/associate_track.go
+++ b/internal/catalog/associate_track.go
@@ -47,6 +47,7 @@ func matchTrackByMbzID(ctx context.Context, d db.TrackStore, opts AssociateTrack
 	l := logger.FromContext(ctx)
 	track, err := d.GetTrack(ctx, db.GetTrackOpts{
 		MusicBrainzID: opts.TrackMbzID,
+		ReleaseID: opts.AlbumID,
 	})
 	if err == nil {
 		l.Debug().Msgf("Found track '%s' by MusicBrainz ID", track.Title)

--- a/internal/db/psql/track.go
+++ b/internal/db/psql/track.go
@@ -21,9 +21,12 @@ func (d *Psql) GetTrack(ctx context.Context, opts db.GetTrackOpts) (*models.Trac
 	l := logger.FromContext(ctx)
 	var track models.Track
 
-	if opts.MusicBrainzID != uuid.Nil {
+	if opts.MusicBrainzID != uuid.Nil && opts.ReleaseID != 0 {
 		l.Debug().Msgf("Fetching track from DB with MusicBrainz ID %s", opts.MusicBrainzID)
-		t, err := d.q.GetTrackByMbzID(ctx, &opts.MusicBrainzID)
+		t, err := d.q.GetTrackByMbzID(ctx, repository.GetTrackByMbzIDParams{
+			MusicBrainzID: &opts.MusicBrainzID,
+			ReleaseID:     opts.ReleaseID,
+		})
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, fmt.Errorf("GetTrack: GetTrackByMbzID: %w", db.ErrNotFound)
 		}

--- a/internal/db/psql/track_test.go
+++ b/internal/db/psql/track_test.go
@@ -89,7 +89,7 @@ func TestGetTrack(t *testing.T) {
 	assert.EqualValues(t, 100, track.TimeListened)
 
 	// Test GetTrack by MusicBrainzID
-	track, err = store.GetTrack(ctx, db.GetTrackOpts{MusicBrainzID: uuid.MustParse("22222222-2222-2222-2222-222222222222")})
+	track, err = store.GetTrack(ctx, db.GetTrackOpts{MusicBrainzID: uuid.MustParse("22222222-2222-2222-2222-222222222222"), ReleaseID: 2})
 	require.NoError(t, err)
 	assert.Equal(t, int32(2), track.ID)
 	assert.Equal(t, "Track Two", track.Title)

--- a/internal/db/sqlite/track.go
+++ b/internal/db/sqlite/track.go
@@ -15,10 +15,10 @@ import (
 )
 
 func (s *Sqlite) GetTrack(ctx context.Context, opts db.GetTrackOpts) (*models.Track, error) {
-	if opts.MusicBrainzID != uuid.Nil {
+	if opts.MusicBrainzID != uuid.Nil && opts.ReleaseID != 0 {
 		var id int32
 		err := s.db.QueryRowContext(ctx,
-			`SELECT id FROM tracks WHERE musicbrainz_id = ? LIMIT 1`, opts.MusicBrainzID.String()).Scan(&id)
+			`SELECT id FROM tracks WHERE musicbrainz_id = ? AND release_id = ? LIMIT 1`, opts.MusicBrainzID.String(), opts.ReleaseID).Scan(&id)
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, fmt.Errorf("GetTrack: by MbzID: %w", db.ErrNotFound)
 		}

--- a/internal/repository/track.sql.go
+++ b/internal/repository/track.sql.go
@@ -463,11 +463,16 @@ func (q *Queries) GetTrackAllTimeRank(ctx context.Context, id int32) (GetTrackAl
 
 const getTrackByMbzID = `-- name: GetTrackByMbzID :one
 SELECT id, musicbrainz_id, duration, release_id, title FROM tracks_with_title
-WHERE musicbrainz_id = $1 LIMIT 1
+WHERE musicbrainz_id = $1 AND release_id = $2 LIMIT 1
 `
 
-func (q *Queries) GetTrackByMbzID(ctx context.Context, musicbrainzID *uuid.UUID) (TracksWithTitle, error) {
-	row := q.db.QueryRow(ctx, getTrackByMbzID, musicbrainzID)
+type GetTrackByMbzIDParams struct {
+	MusicBrainzID *uuid.UUID
+	ReleaseID     int32
+}
+
+func (q *Queries) GetTrackByMbzID(ctx context.Context, arg GetTrackByMbzIDParams) (TracksWithTitle, error) {
+	row := q.db.QueryRow(ctx, getTrackByMbzID, arg.MusicBrainzID, arg.ReleaseID)
 	var i TracksWithTitle
 	err := row.Scan(
 		&i.ID,


### PR DESCRIPTION
My attempt to fix #34 .

## Description
When looking up a track from db, include the corresponding release_id as a filter as well instead of just querying by its track_id.

In this way, when multiple albums contain the same recording of a track, they will be correctly scrobbled to their respective albums.

## Related Issue(s)
Fixes #34 

## Type of Change
- [√] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [√ ] Unit Tests
- [√ ] Manual Testing (please describe steps)

## Checklist
- [√] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [√] I have ensured my changes generate no new warnings

## AI/LLM Usage
<!-- If no AI/LLMs were used, you may skip this portion of the template -->
- [ ] I disclose that XX% of the code in this PR is written by an LLM. (please estimate)
- [ ] I fully understand all changes made by LLM-generated code.
- [ ] I have not and will not use an LLM to write any part of this PR description or PR comments.

This time I used AI to give me a whole picture of this project, so I didn't have to peruse all of the codes.

## Screenshots (if applicable)
<img width="1017" height="390" alt="image" src="https://github.com/user-attachments/assets/be045fd6-65aa-49c5-87a0-ffbb9251403f" />


