### PR TITLE
fix: add and remove artists from track in sqlite

### DIFF
--- a/engine/long_test.go
+++ b/engine/long_test.go
@@ -950,6 +950,56 @@ func TestSetPrimaryArtist(t *testing.T) {
 	assert.EqualValues(t, 1, count, "expected only one primary artist for track")
 }
 
+func TestUpdateArtists_Track(t *testing.T) {
+	truncateTestData(t)
+	t.Run("Submit Listens", doSubmitListens)
+
+	// happy path: add artist 2 to track 1
+	resp, err := makeAuthRequest(t, session, "PATCH", "/apis/web/v1/track?id=1&add_artist=2", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	exists, err := store.RowExists(`
+		SELECT EXISTS (
+			SELECT 1 FROM artist_tracks
+			WHERE track_id = $1 AND artist_id = $2
+		)`, 1, 2)
+	require.NoError(t, err)
+	assert.True(t, exists, "expected artist 2 to be associated with track 1")
+
+	// happy path: remove artist 2 from track 1
+	resp, err = makeAuthRequest(t, session, "PATCH", "/apis/web/v1/track?id=1&remove_artist=2", nil)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	exists, err = store.RowExists(`
+		SELECT EXISTS (
+			SELECT 1 FROM artist_tracks
+			WHERE track_id = $1 AND artist_id = $2
+		)`, 1, 2)
+	require.NoError(t, err)
+	assert.False(t, exists, "expected artist 2 to be removed from track 1")
+
+	// 401 Unauthorized
+	req, err := http.NewRequest("PATCH", host()+"/apis/web/v1/track?id=1&add_artist=2", nil)
+	require.NoError(t, err)
+	resp, err = http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+
+	// 400 Bad Request: invalid id
+	resp, err = makeAuthRequest(t, session, "PATCH", "/apis/web/v1/track?id=notanumber&add_artist=2", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	// 400 Bad Request: invalid add_artist
+	resp, err = makeAuthRequest(t, session, "PATCH", "/apis/web/v1/track?id=1&add_artist=notanumber", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	truncateTestData(t)
+}
+
 func TestManualListen(t *testing.T) {
 	truncateTestData(t)
 	t.Run("Submit Listens", doSubmitListens)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -64,6 +64,7 @@ type TrackStore interface {
 	SearchTracks(ctx context.Context, q string) ([]*models.Track, error)
 	CountTracks(ctx context.Context, timeframe Timeframe) (int64, error)
 	CountNewTracks(ctx context.Context, timeframe Timeframe) (int64, error)
+	AddArtistsToAlbum(ctx context.Context, opts AddArtistsToAlbumOpts) error
 }
 
 type ListenStore interface {

--- a/internal/db/opts.go
+++ b/internal/db/opts.go
@@ -118,6 +118,11 @@ type AddArtistsToAlbumOpts struct {
 	ArtistIDs []int32
 }
 
+type AddArtistsToTrackOpts struct {
+	TrackID   int32
+	ArtistIDs []int32
+}
+
 type GetItemsOpts struct {
 	Limit     int
 	Page      int

--- a/internal/db/sqlite/track.go
+++ b/internal/db/sqlite/track.go
@@ -223,6 +223,22 @@ func (s *Sqlite) SaveTrackAliases(ctx context.Context, id int32, aliases []strin
 	return tx.Commit()
 }
 
+func (s *Sqlite) AddArtistsToTrack(ctx context.Context, opts db.AddArtistsToTrackOpts) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("AddArtistsToTrack: BeginTx: %w", err)
+	}
+	defer tx.Rollback()
+	for _, artistID := range opts.ArtistIDs {
+		if _, err := tx.ExecContext(ctx,
+			`INSERT OR IGNORE INTO artist_tracks (artist_id, track_id, is_primary) VALUES (?,?,0)`,
+			artistID, opts.TrackID); err != nil {
+			return fmt.Errorf("AddArtistsToTrack: insert: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
 func (s *Sqlite) UpdateTrack(ctx context.Context, opts db.UpdateTrackOpts) error {
 	if opts.ID == 0 {
 		return errors.New("UpdateTrack: track id not specified")
@@ -245,6 +261,43 @@ func (s *Sqlite) UpdateTrack(ctx context.Context, opts db.UpdateTrackOpts) error
 			`UPDATE tracks SET duration = ? WHERE id = ?`,
 			opts.Duration, opts.ID); err != nil {
 			return fmt.Errorf("UpdateTrack: duration: %w", err)
+		}
+	}
+	if len(opts.AddArtists) > 0 {
+		var releaseID int32
+		if t, err := s.GetTrack(ctx, db.GetTrackOpts{ID: opts.ID}); err != nil {
+			return fmt.Errorf("UpdateTrack: GetTrack By ID: %w", err)
+		} else {
+			releaseID = t.AlbumID
+		}
+
+		if err = s.AddArtistsToTrack(ctx, db.AddArtistsToTrackOpts{
+			TrackID:   opts.ID,
+			ArtistIDs: opts.AddArtists,
+		}); err != nil {
+			return fmt.Errorf("UpdateTrack: AssociateArtistToTrack: %w", err)
+		}
+		if err = s.AddArtistsToAlbum(ctx, db.AddArtistsToAlbumOpts{
+			ArtistIDs: opts.AddArtists,
+			AlbumID:   releaseID,
+		}); err != nil {
+			return fmt.Errorf("UpdateTrack: AssociateArtistToRelease: %w", err)
+		}
+	}
+
+	if len(opts.RemoveArtists) > 0 {
+		for _, aid := range opts.RemoveArtists {
+			if _, err = tx.ExecContext(ctx, `DELETE FROM artist_tracks
+					WHERE artist_id = ?
+					  AND track_id = ?
+					  AND is_primary = false;`,
+				aid, opts.ID,
+			); err != nil {
+				return fmt.Errorf("UpdateTrack: RemoveArtists: %w", err)
+			}
+		}
+		if err = cleanOrphanedEntries(ctx, tx); err != nil {
+			return fmt.Errorf("UpdateTrack: CleanOrphanedEntries: %w", err)
 		}
 	}
 	return tx.Commit()


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes and the motivation behind them. -->
Adds a missing implementation for adding and removing artists with SQLite enabled.

## Related Issue(s)
<!-- Link to the issue this PR addresses (e.g., Fixes #123) -->
n/a

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] Unit Tests
- [x] Manual Testing (please describe steps)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have ensured my changes generate no new warnings

## AI/LLM Usage
<!-- If no AI/LLMs were used, you may skip this portion of the template -->
- [x] I disclose that 20% of the code in this PR is written by an LLM. (please estimate)
- [x] I fully understand all changes made by LLM-generated code.
- [x] I have not and will not use an LLM to write any part of this PR description or PR comments.
claude wrote the integration test

## Screenshots (if applicable)
<!-- Add screenshots or screen recordings to help the reviewer understand the UI changes. -->

