### PR TITLE
feat: purge all data endpoint

### DIFF
--- a/engine/handlers/delete.go
+++ b/engine/handlers/delete.go
@@ -163,3 +163,21 @@ func DeleteAlbumHandler(store db.AlbumStore) http.HandlerFunc {
 		w.WriteHeader(http.StatusNoContent)
 	}
 }
+
+func PurgeAllDataHandler(store db.DB) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		l := logger.FromContext(ctx)
+
+		l.Debug().Msg("PurgeAllDataHandler: Received request to purge all data")
+
+		if err := store.PurgeAllData(ctx); err != nil {
+			l.Err(err).Msg("PurgeAllDataHandler: Failed to purge all data")
+			utils.WriteError(w, "failed to purge data", http.StatusInternalServerError)
+			return
+		}
+
+		l.Debug().Msg("PurgeAllDataHandler: Successfully purged all data")
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/engine/routes.go
+++ b/engine/routes.go
@@ -84,6 +84,7 @@ func bindRoutes(
 			r.Post("/merge/tracks", handlers.MergeTracksHandler(db))
 			r.Post("/merge/albums", handlers.MergeReleaseGroupsHandler(db))
 			r.Post("/merge/artists", handlers.MergeArtistsHandler(db))
+			r.Delete("/data", handlers.PurgeAllDataHandler(db))
 			r.Delete("/artist", handlers.DeleteArtistHandler(db))
 			r.Post("/artists/primary", handlers.SetPrimaryArtistHandler(db))
 			r.Delete("/album", handlers.DeleteAlbumHandler(db))

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -115,4 +115,5 @@ type DB interface {
 	ExportStore
 	Ping(ctx context.Context) error
 	Close(ctx context.Context)
+	PurgeAllData(ctx context.Context) error
 }

--- a/internal/db/psql/psql.go
+++ b/internal/db/psql/psql.go
@@ -4,6 +4,7 @@ package psql
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"time"
 
@@ -95,6 +96,10 @@ func (d *Psql) Close(ctx context.Context) {
 
 func (d *Psql) Ping(ctx context.Context) error {
 	return d.conn.Ping(ctx)
+}
+
+func (d *Psql) PurgeAllData(_ context.Context) error {
+	return errors.New("PurgeAllData: not implemented for psql")
 }
 
 func stepToInterval(p db.StepInterval) pgtype.Interval {

--- a/internal/db/sqlite/sqlite.go
+++ b/internal/db/sqlite/sqlite.go
@@ -280,5 +280,26 @@ func cleanOrphanedEntries(ctx context.Context, tx *sql.Tx) error {
 	return nil
 }
 
+func (s *Sqlite) PurgeAllData(ctx context.Context) error {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("PurgeAllData: BeginTx: %w", err)
+	}
+	defer tx.Rollback()
+	// Order respects foreign-key dependencies; cascades clean up junction and
+	// alias tables automatically.
+	for _, stmt := range []string{
+		`DELETE FROM listens`,
+		`DELETE FROM tracks`,
+		`DELETE FROM releases`,
+		`DELETE FROM artists`,
+	} {
+		if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("PurgeAllData: %w", err)
+		}
+	}
+	return tx.Commit()
+}
+
 // compile-time assertion that *Sqlite implements db.DB
 var _ db.DB = (*Sqlite)(nil)


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes and the motivation behind them. -->
This PR only adds an authenticated endpoint to purge all artist, album, and track data from the database. UI for this feature will be added in a later UI refresh.

Only works with SQLite. Not planned for PostgreSQL.

## Related Issue(s)
<!-- Link to the issue this PR addresses (e.g., Fixes #123) -->
n/a 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] Unit Tests
- [x] Manual Testing (please describe steps)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have ensured my changes generate no new warnings

## AI/LLM Usage
<!-- If no AI/LLMs were used, you may skip this portion of the template -->
- [x] I disclose that 100% of the code in this PR is written by an LLM. (please estimate)
- [x] I fully understand all changes made by LLM-generated code.
- [x] I have not and will not use an LLM to write any part of this PR description or PR comments.

## Screenshots (if applicable)
<!-- Add screenshots or screen recordings to help the reviewer understand the UI changes. -->

