### PR TITLE
fix: run psql migrations before migrating to sqlite

### DIFF
--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"time"
 
+	"github.com/gabehf/koito/db/migrations"
 	migrations_sqlite "github.com/gabehf/koito/db/migrations_sqlite"
 	"github.com/gabehf/koito/internal/cfg"
 	_ "github.com/jackc/pgx/v5/stdlib"
@@ -33,6 +34,12 @@ func Migrate(ctx context.Context, l *zerolog.Logger) error {
 	defer pgDB.Close()
 	if err := pgDB.PingContext(ctx); err != nil {
 		return fmt.Errorf("migrate: ping postgres: %w", err)
+	}
+
+	goose.SetBaseFS(migrations.Files)
+
+	if err := goose.Up(pgDB, "."); err != nil {
+		return fmt.Errorf("migrate: psql schema migration: %w", err)
 	}
 
 	sqliteDSN := path.Join(cfg.ConfigDir(), "koito.db") +


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes and the motivation behind them. -->
Ensures all PostgreSQL migrations are run before migrating to SQLite. This is to ensure that the migration runs without any issues for those upgrading from v0.1.4 or older to v0.2.0.

## Related Issue(s)
<!-- Link to the issue this PR addresses (e.g., Fixes #123) -->

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] Unit Tests
- [x] Manual Testing (please describe steps)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have ensured my changes generate no new warnings

## AI/LLM Usage
<!-- If no AI/LLMs were used, you may skip this portion of the template -->
- [x] I disclose that 0% of the code in this PR is written by an LLM. (please estimate)
- [ ] I fully understand all changes made by LLM-generated code.
- [ ] I have not and will not use an LLM to write any part of this PR description or PR comments.

## Screenshots (if applicable)
<!-- Add screenshots or screen recordings to help the reviewer understand the UI changes. -->

