### PR TITLE
Adjust "Rewind" Page Behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  
+
 ![Koito logo](https://github.com/user-attachments/assets/bd69a050-b40f-4da7-8ff1-4607554bfd6d)
 
 *Koito (小糸) is a Japanese surname. It is also homophonous with the words 恋と (koi to), meaning "and/with love".*
@@ -7,12 +7,12 @@
 </div>
 
 <div align="center">
-  
+
   [![Ko-Fi](https://img.shields.io/badge/Ko--fi-F16061?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/gabehf)
-  
+
 </div>
 
-Koito is a modern, themeable ListenBrainz-compatible scrobbler for self-hosters who want control over their data and insights into their listening habits. 
+Koito is a modern, themeable ListenBrainz-compatible scrobbler for self-hosters who want control over their data and insights into their listening habits.
 It supports relaying to other compatible scrobblers, so you can try it safely without replacing your current setup.
 
 > This project is under active development and still considered "unstable", and therefore you can expect some bugs. If you don't want to replace your current scrobbler
@@ -37,7 +37,6 @@ You can view my public instance with my listening data at https://koito.mnrva.de
 ![screenshot one](assets/screenshot1.png)
 <img width="2021" height="1330" alt="image" src="https://github.com/user-attachments/assets/956748ff-f61f-4102-94b2-50783d9ee72b" />
 <img width="1505" height="1018" alt="image" src="https://github.com/user-attachments/assets/5f7e1162-f723-4e4b-a528-06cf26d1d870" />
-
 
 ## Installation
 
@@ -94,4 +93,4 @@ Not just during development, you can see my complete listening data on my [live 
 #### Random notes
 
 - I find it a little annoying when READMEs use emoji but everyone else is doing it so I felt like I had to...
-- About 50% of the reason I built this was minor/not-so-minor greivances with Maloja. Could I have just contributed to Maloja? Maybe, but I like building stuff and I like Koito's UI a lot more anyways.
+- About 50% of the reason I built this was minor/not-so-minor grievances with Maloja. Could I have just contributed to Maloja? Maybe, but I like building stuff and I like Koito's UI a lot more anyways.

--- a/client/app/routes/RewindPage.tsx
+++ b/client/app/routes/RewindPage.tsx
@@ -137,6 +137,10 @@ export default function RewindPage() {
   };
 
   const setRewindView = (view: "year" | "month") => {
+    if (view === rewindView) {
+      return;
+    }
+
     if (view === "year") {
       updateParams({
         year: year.toString(),
@@ -189,6 +193,7 @@ export default function RewindPage() {
               <div className="flex w-[15rem] items-center rounded-lg bg p-1">
                 <button
                   onClick={() => setRewindView("year")}
+                  disabled={rewindView === "year"}
                   className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors hover-bg-secondary ${
                     rewindView === "year"
                       ? "bg-secondary"
@@ -199,6 +204,7 @@ export default function RewindPage() {
                 </button>
                 <button
                   onClick={() => setRewindView("month")}
+                  disabled={rewindView === "month"}
                   className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors hover-bg-secondary ${
                     rewindView === "month"
                       ? "bg-secondary"

--- a/client/app/routes/RewindPage.tsx
+++ b/client/app/routes/RewindPage.tsx
@@ -58,6 +58,10 @@ export default function RewindPage() {
   const [showTime, setShowTime] = useState(false);
   const { stats: stats } = useLoaderData<{ stats: RewindStats }>();
   const latestRewindParams = getRewindParams();
+  const latestMonthlyRewindParams = {
+    year: latestRewindParams.year,
+    month: latestRewindParams.month === 0 ? 12 : latestRewindParams.month,
+  };
   const rewindView = month === 0 ? "year" : "month";
 
   const [bgColor, setBgColor] = useState<string>("(--color-bg)");
@@ -119,9 +123,9 @@ export default function RewindPage() {
 
   const nextMonthParams = getAdjacentMonthParams(year, month, "next");
   const disableNextMonth =
-    nextMonthParams.year > latestRewindParams.year ||
-    (nextMonthParams.year === latestRewindParams.year &&
-      nextMonthParams.month > latestRewindParams.month);
+    nextMonthParams.year > latestMonthlyRewindParams.year ||
+    (nextMonthParams.year === latestMonthlyRewindParams.year &&
+      nextMonthParams.month > latestMonthlyRewindParams.month);
 
   const navigateMonth = (direction: "prev" | "next") => {
     const nextParams = getAdjacentMonthParams(year, month, direction);
@@ -141,7 +145,10 @@ export default function RewindPage() {
       return;
     }
 
-    const nextMonth = year === latestRewindParams.year ? latestRewindParams.month : 12;
+    const nextMonth =
+      year === latestMonthlyRewindParams.year
+        ? latestMonthlyRewindParams.month
+        : 12;
 
     updateParams({
       year: year.toString(),

--- a/client/app/routes/RewindPage.tsx
+++ b/client/app/routes/RewindPage.tsx
@@ -4,7 +4,7 @@ import { imageUrl, type RewindStats } from "api/api";
 import { useEffect, useState } from "react";
 import type { LoaderFunctionArgs } from "react-router";
 import { useLoaderData } from "react-router";
-import { getRewindParams, getRewindYear } from "~/utils/utils";
+import { getRewindParams } from "~/utils/utils";
 import { useNavigate } from "react-router";
 import { average } from "color.js";
 import { ChevronLeft, ChevronRight } from "lucide-react";
@@ -57,6 +57,7 @@ export default function RewindPage() {
   const navigate = useNavigate();
   const [showTime, setShowTime] = useState(false);
   const { stats: stats } = useLoaderData<{ stats: RewindStats }>();
+  const latestRewindParams = getRewindParams();
 
   const [bgColor, setBgColor] = useState<string>("(--color-bg)");
 
@@ -87,25 +88,46 @@ export default function RewindPage() {
     navigate(url, { replace: false });
   };
 
-  const navigateMonth = (direction: "prev" | "next") => {
+  const getAdjacentMonthParams = (
+    currentYear: number,
+    currentMonth: number,
+    direction: "prev" | "next"
+  ) => {
     if (direction === "next") {
-      if (month === 12) {
-        month = 0;
-      } else {
-        month += 1;
+      if (currentMonth === 12) {
+        return { year: currentYear + 1, month: 1 };
       }
-    } else {
-      if (month === 0) {
-        month = 12;
-      } else {
-        month -= 1;
+
+      if (currentMonth === 0) {
+        return { year: currentYear, month: 1 };
       }
+
+      return { year: currentYear, month: currentMonth + 1 };
     }
-    console.log(`Month: ${month}`);
+
+    if (currentMonth === 1) {
+      return { year: currentYear - 1, month: 12 };
+    }
+
+    if (currentMonth === 0) {
+      return { year: currentYear - 1, month: 12 };
+    }
+
+    return { year: currentYear, month: currentMonth - 1 };
+  };
+
+  const nextMonthParams = getAdjacentMonthParams(year, month, "next");
+  const disableNextMonth =
+    nextMonthParams.year > latestRewindParams.year ||
+    (nextMonthParams.year === latestRewindParams.year &&
+      nextMonthParams.month > latestRewindParams.month);
+
+  const navigateMonth = (direction: "prev" | "next") => {
+    const nextParams = getAdjacentMonthParams(year, month, direction);
 
     updateParams({
-      year: year.toString(),
-      month: month.toString(),
+      year: nextParams.year.toString(),
+      month: nextParams.month.toString(),
     });
   };
   const navigateYear = (direction: "prev" | "next") => {
@@ -142,12 +164,6 @@ export default function RewindPage() {
                 <button
                   onClick={() => navigateMonth("prev")}
                   className="p-2 disabled:text-(--color-fg-tertiary)"
-                  disabled={
-                    // Previous month is in the future OR
-                    new Date(year, month - 2) > new Date() ||
-                    // We are looking at current year and prev would take us to full year
-                    (new Date().getFullYear() === year && month === 1)
-                  }
                 >
                   <ChevronLeft size={20} />
                 </button>
@@ -157,12 +173,7 @@ export default function RewindPage() {
                 <button
                   onClick={() => navigateMonth("next")}
                   className="p-2 disabled:text-(--color-fg-tertiary)"
-                  disabled={
-                    // next month is current or future month and
-                    month >= new Date().getMonth() &&
-                    // we are looking at current (or future) year
-                    year >= new Date().getFullYear()
-                  }
+                  disabled={disableNextMonth}
                 >
                   <ChevronRight size={20} />
                 </button>

--- a/client/app/routes/RewindPage.tsx
+++ b/client/app/routes/RewindPage.tsx
@@ -58,6 +58,7 @@ export default function RewindPage() {
   const [showTime, setShowTime] = useState(false);
   const { stats: stats } = useLoaderData<{ stats: RewindStats }>();
   const latestRewindParams = getRewindParams();
+  const rewindView = month === 0 ? "year" : "month";
 
   const [bgColor, setBgColor] = useState<string>("(--color-bg)");
 
@@ -130,6 +131,24 @@ export default function RewindPage() {
       month: nextParams.month.toString(),
     });
   };
+
+  const setRewindView = (view: "year" | "month") => {
+    if (view === "year") {
+      updateParams({
+        year: year.toString(),
+        month: "0",
+      });
+      return;
+    }
+
+    const nextMonth = year === latestRewindParams.year ? latestRewindParams.month : 12;
+
+    updateParams({
+      year: year.toString(),
+      month: nextMonth.toString(),
+    });
+  };
+
   const navigateYear = (direction: "prev" | "next") => {
     if (direction === "next") {
       year += 1;
@@ -160,25 +179,49 @@ export default function RewindPage() {
         <div className="flex flex-col lg:flex-row items-start lg:mt-15 mt-5 gap-10 w-19/20 px-5 md:px-20">
           <div className="flex flex-col items-start gap-4">
             <div className="flex flex-col items-start gap-4 py-8">
-              <div className="flex items-center gap-6 justify-around">
+              <div className="flex w-[15rem] items-center rounded-lg bg p-1">
                 <button
-                  onClick={() => navigateMonth("prev")}
-                  className="p-2 disabled:text-(--color-fg-tertiary)"
+                  onClick={() => setRewindView("year")}
+                  className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors hover-bg-secondary ${
+                    rewindView === "year"
+                      ? "bg-secondary"
+                      : "color-fg-secondary"
+                  }`}
                 >
-                  <ChevronLeft size={20} />
+                  Full Year
                 </button>
-                <p className="font-medium text-xl text-center w-30">
-                  {months[month]}
-                </p>
                 <button
-                  onClick={() => navigateMonth("next")}
-                  className="p-2 disabled:text-(--color-fg-tertiary)"
-                  disabled={disableNextMonth}
+                  onClick={() => setRewindView("month")}
+                  className={`flex-1 rounded-md px-3 py-1.5 text-sm font-medium transition-colors hover-bg-secondary ${
+                    rewindView === "month"
+                      ? "bg-secondary"
+                      : "color-fg-secondary"
+                  }`}
                 >
-                  <ChevronRight size={20} />
+                  Monthly
                 </button>
               </div>
-              <div className="flex items-center gap-6 justify-around">
+              {rewindView === "month" && (
+                <div className="flex w-[15rem] items-center justify-between">
+                  <button
+                    onClick={() => navigateMonth("prev")}
+                    className="p-2 disabled:text-(--color-fg-tertiary)"
+                  >
+                    <ChevronLeft size={20} />
+                  </button>
+                  <p className="font-medium text-xl text-center w-30">
+                    {months[month]}
+                  </p>
+                  <button
+                    onClick={() => navigateMonth("next")}
+                    className="p-2 disabled:text-(--color-fg-tertiary)"
+                    disabled={disableNextMonth}
+                  >
+                    <ChevronRight size={20} />
+                  </button>
+                </div>
+              )}
+              <div className="flex w-[15rem] items-center justify-between">
                 <button
                   onClick={() => navigateYear("prev")}
                   className="p-2 disabled:text-(--color-fg-tertiary)"


### PR DESCRIPTION
Nice project! I have been testing out Koito for a few days and have been enjoying it.

## Description

While using the "Rewind" page, I ran into some confusing behavior. 

1. I was surprised that the "Full Year" was between Dec and Jan.
2. When I hit the "previous" arrow while on January, the month switched to December, but the year didn't switch.

In this PR, I add a toggle for "Full Year" vs. "Monthly" rewind types AND change the year when it makes sense (i.e. Dec -> Jan).

I ensured that the new element used the color schemes built into Koito.


## Type of Change
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Video attached of me running the server and frontend locally for testing (I imported a few months data).

https://github.com/user-attachments/assets/d80089f2-000e-4896-87a1-4b6f92cff55c

## Checklist
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [x] I have ensured my changes generate no new warnings

## AI/LLM Usage
<!-- If no AI/LLMs were used, you may skip this portion of the template -->
- [X] I disclose that 100% of the code in this PR is written by an LLM.
- [X] I fully understand all changes made by LLM-generated code.
- [X] I have not and will not use an LLM to write any part of this PR description or PR comments.