### PR TITLE
feat: add axes and tooltip to interest over time graph

### DIFF
--- a/client/app/components/InterestGraph.tsx
+++ b/client/app/components/InterestGraph.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiFetch, type InterestBucket } from "api/api";
 import { useTheme } from "~/hooks/useTheme";
-import { Area, AreaChart } from "recharts";
+import { Area, AreaChart, XAxis, YAxis, Tooltip } from "recharts";
 import CardHeader from "./primitives/CardHeader";
 
 interface Props {
@@ -15,6 +15,36 @@ const getInterest = (args: { buckets: number; type: string; id: number }) =>
     `/apis/web/v1/${args.type.toLowerCase()}/${args.id}/interest`,
     args,
   );
+
+interface InterestTooltipProps {
+  active?: boolean;
+  payload?: { payload: InterestBucket }[];
+}
+
+function InterestTooltip({ active, payload }: InterestTooltipProps) {
+  if (!active || !payload || !payload.length) {
+    return null;
+  }
+  const bucket = payload[0].payload;
+  const start = new Date(bucket.bucket_start);
+  const end = new Date(bucket.bucket_end);
+  const range =
+    start.toDateString() === end.toDateString()
+      ? start.toLocaleDateString()
+      : `${start.toLocaleDateString()} – ${end.toLocaleDateString()}`;
+
+  return (
+    <div className="bg-(--color-bg) color-fg border-1 border-(--color-bg-tertiary) px-3 py-2 rounded-lg text-[12px]">
+      <p className="text-(--color-fg-secondary)">{range}</p>
+      <p>
+        <span className="text-(--color-primary) font-semibold">
+          {bucket.listen_count}
+        </span>{" "}
+        play{bucket.listen_count !== 1 ? "s" : ""}
+      </p>
+    </div>
+  );
+}
 
 export default function InterestGraph({ buckets = 16, type, id }: Props) {
   const args = {
@@ -59,7 +89,7 @@ export default function InterestGraph({ buckets = 16, type, id }: Props) {
             height: "120px",
           }}
           data={data}
-          margin={{ top: 20, bottom: 15 }}
+          margin={{ top: 20, right: 10, bottom: 5, left: -20 }}
         >
           <defs>
             <linearGradient id="colorGradient" x1="0" y1="0" x2="0" y2="1">
@@ -67,6 +97,27 @@ export default function InterestGraph({ buckets = 16, type, id }: Props) {
               <stop offset="95%" stopColor={color} stopOpacity={0} />
             </linearGradient>
           </defs>
+          <XAxis
+            dataKey="bucket_start"
+            tickFormatter={(v) => new Date(v).toLocaleDateString()}
+            stroke="var(--color-fg-tertiary)"
+            tick={{ fontSize: 11 }}
+            tickLine={false}
+            axisLine={false}
+            minTickGap={40}
+          />
+          <YAxis
+            allowDecimals={false}
+            stroke="var(--color-fg-tertiary)"
+            tick={{ fontSize: 11 }}
+            tickLine={false}
+            axisLine={false}
+            width={40}
+          />
+          <Tooltip
+            content={<InterestTooltip />}
+            cursor={{ stroke: "var(--color-fg-tertiary)", strokeWidth: 1 }}
+          />
           <Area
             dataKey="listen_count"
             type="natural"

--- a/client/app/components/InterestGraph.tsx
+++ b/client/app/components/InterestGraph.tsx
@@ -89,7 +89,7 @@ export default function InterestGraph({ buckets = 16, type, id }: Props) {
             height: "120px",
           }}
           data={data}
-          margin={{ top: 20, right: 10, bottom: 5, left: -20 }}
+          margin={{ top: 20, right: 10, bottom: 5, left: 0 }}
         >
           <defs>
             <linearGradient id="colorGradient" x1="0" y1="0" x2="0" y2="1">


### PR DESCRIPTION
## Description
The current graph for interest over time is a curve without information on the X and Y axes. This PR adds song listen count on the Y axis, and date to the X axis. The graph is already divided into 16 parts that adapt automatically regarding how long the song has been in the database for. This only adds the visual data.

The current implementation displays the dates using the browser's locale. If the PR for the date format is merged, this can also be adapted to follow what's set in the variable.

## Related Issue(s)
N/A

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] Unit Tests
- [X] Manual Testing (please describe steps)
1. Check "interest over time" graph for tracks, albums, and artists.
2. The graph should show on the Y axis the play count
3. The graph should show on the X axis the dates
4. Hover the mouse over the graph : it shows a tooltip for 16 parts of the graph
5. The date range and listen counts automatically adapts to how long and how many times you've been listening to a song, artist, or album
6. The date range and listen count in the tooltip also automatically adapts
7. On a song that has no period of listening history (like for a song I listened to the first time today), the date in the tooltip shows a single date, not a range

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] I have ensured my changes generate no new warnings

## AI/LLM Usage
<!-- If no AI/LLMs were used, you may skip this portion of the template -->
- [X] I disclose that 100% of the code in this PR is written by an LLM. (please estimate)
- [X] I fully understand all changes made by LLM-generated code.
- [X] I have not and will not use an LLM to write any part of this PR description or PR comments.

## Screenshots (if applicable)
<img width="583" height="260" alt="image" src="https://github.com/user-attachments/assets/6b272743-4de9-4661-b723-e8b6a99d46fd" />

