### PR TITLE
fix: Distinguish between tracks with the same title but different

### DIFF
--- a/internal/catalog/associate_track.go
+++ b/internal/catalog/associate_track.go
@@ -87,43 +87,48 @@ func matchTrackByTrackInfo(ctx context.Context, d db.TrackStore, opts AssociateT
 		ArtistIDs: opts.ArtistIDs,
 	})
 	if err == nil {
-		l.Debug().Msgf("Track '%s' found by title, release and artist match", track.Title)
-		return track, nil
+		if opts.TrackMbzID == uuid.Nil || track.MbzID == nil || *track.MbzID == uuid.Nil || *track.MbzID == opts.TrackMbzID {
+			l.Debug().Msgf("Track '%s' found by title, release and artist match", track.Title)
+			return track, nil
+		}
+		// Two distinct recordings sharing same title, fall through to create a new track
+		l.Debug().Msgf("Track '%s' found but has a different MusicBrainz ID (%s != %s)",
+			track.Title, track.MbzID.String(), opts.TrackMbzID.String())
 	} else if !errors.Is(err, db.ErrNotFound) {
 		return nil, fmt.Errorf("matchTrackByTrackInfo: %w", err)
-	} else {
-		if opts.TrackMbzID != uuid.Nil {
-			mbzTrack, err := opts.Mbzc.GetTrack(ctx, opts.TrackMbzID)
+	}
+
+	if opts.TrackMbzID != uuid.Nil {
+		mbzTrack, err := opts.Mbzc.GetTrack(ctx, opts.TrackMbzID)
+		if err == nil {
+			track, err := d.GetTrack(ctx, db.GetTrackOpts{
+				Title:     mbzTrack.Title,
+				ReleaseID: opts.AlbumID,
+				ArtistIDs: opts.ArtistIDs,
+			})
 			if err == nil {
-				track, err := d.GetTrack(ctx, db.GetTrackOpts{
-					Title:     mbzTrack.Title,
-					ReleaseID: opts.AlbumID,
-					ArtistIDs: opts.ArtistIDs,
-				})
-				if err == nil {
-					if track.MbzID == nil || *track.MbzID == uuid.Nil || *track.MbzID == opts.TrackMbzID {
-						l.Debug().Msgf("Track '%s' found by MusicBrainz title, release and artist match", opts.TrackName)
-						return track, nil
-					}
+				if track.MbzID == nil || *track.MbzID == uuid.Nil || *track.MbzID == opts.TrackMbzID {
+					l.Debug().Msgf("Track '%s' found by MusicBrainz title, release and artist match", opts.TrackName)
+					return track, nil
 				}
 			}
 		}
-		l.Debug().Msgf("Track '%s' could not be found by title and artist match", opts.TrackName)
-		t, err := d.SaveTrack(ctx, db.SaveTrackOpts{
-			RecordingMbzID: opts.TrackMbzID,
-			AlbumID:        opts.AlbumID,
-			Title:          opts.TrackName,
-			ArtistIDs:      opts.ArtistIDs,
-			Duration:       opts.Duration,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("matchTrackByTrackInfo: %w", err)
-		}
-		if opts.TrackMbzID == uuid.Nil {
-			l.Info().Msgf("Created track '%s' with title and artist", opts.TrackName)
-		} else {
-			l.Info().Msgf("Created track '%s' with MusicBrainz Recording ID", opts.TrackName)
-		}
-		return t, nil
 	}
+	l.Debug().Msgf("Track '%s' could not be found by title and artist match", opts.TrackName)
+	t, err := d.SaveTrack(ctx, db.SaveTrackOpts{
+		RecordingMbzID: opts.TrackMbzID,
+		AlbumID:        opts.AlbumID,
+		Title:          opts.TrackName,
+		ArtistIDs:      opts.ArtistIDs,
+		Duration:       opts.Duration,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("matchTrackByTrackInfo: %w", err)
+	}
+	if opts.TrackMbzID == uuid.Nil {
+		l.Info().Msgf("Created track '%s' with title and artist", opts.TrackName)
+	} else {
+		l.Info().Msgf("Created track '%s' with MusicBrainz Recording ID", opts.TrackName)
+	}
+	return t, nil
 }


### PR DESCRIPTION
track_ids

## Description
Some albums have multiple tracks that sharing the same title. For example [Cats](https://musicbrainz.org/release/fb950429-71d1-48ef-be62-ac8676cae86c) has two tracks call Memory, which are totally different (1min vs 5min). Koito treats them as a same recording, this PR is to split them as different ones.

## Related Issue(s)
Following up https://github.com/gabehf/Koito/pull/247

## Type of Change
- [ √] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] Unit Tests
- [ √] Manual Testing (please describe steps)

## Checklist
- [ √] I have performed a self-review of my own code
- [√ ] I have made corresponding changes to the documentation
- [ √] I have ensured my changes generate no new warnings

## AI/LLM Usage
<!-- If no AI/LLMs were used, you may skip this portion of the template -->
- [ ] I disclose that XX% of the code in this PR is written by an LLM. (please estimate)
- [ ] I fully understand all changes made by LLM-generated code.
- [√ ] I have not and will not use an LLM to write any part of this PR description or PR comments.

## Screenshots (if applicable)
<img width="335" height="299" alt="image" src="https://github.com/user-attachments/assets/4e9521c8-d221-4913-85b7-3a578fbbcf59" />
<img width="361" height="305" alt="image" src="https://github.com/user-attachments/assets/80946091-e108-47a6-83a2-6a65380c0ccc" />


