### PR TITLE
fix: proper version format for subsonic ping

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -163,7 +163,7 @@ func Run(
 
 	if cfg.SubsonicEnabled() {
 		l.Debug().Msg("Engine: Checking Subsonic configuration")
-		pingURL := cfg.SubsonicUrl() + "/rest/ping.view?" + cfg.SubsonicParams() + "&f=json&v=1&c=koito"
+		pingURL := cfg.SubsonicUrl() + "/rest/ping.view?" + cfg.SubsonicParams() + "&f=json&v=1.13.0&c=koito"
 
 		resp, err := http.Get(pingURL)
 		if err != nil {


### PR DESCRIPTION
## Description
I assume [LMS](https://github.com/epoupon/lms) expects the OpenSubsonic version to be `1.x.x`, and not a single digit, since [OpenSubsonic versions](https://opensubsonic.netlify.app/docs/subsonic-versions/) are all in semantic version format. `1.13.0` was chosen because all other uses of the version parameter use `1.13.0`.

I don't have Navidrome, so I don't know if this breaks it.

## Related Issue(s)
Fixes https://github.com/gabehf/Koito/issues/211

The other problems in that issue have all already been fixed here or in LMS.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [ ] Unit Tests
- [x] Manual Testing (please describe steps)

Built container with Podman and ran it with my current stable configuration and database (but with the subsonic envs enabled now). Everything works fine.

## Checklist
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have ensured my changes generate no new warnings

## AI/LLM Usage
<!-- If no AI/LLMs were used, you may skip this portion of the template -->
- [ ] I disclose that XX% of the code in this PR is written by an LLM. (please estimate)
- [ ] I fully understand all changes made by LLM-generated code.
- [ ] I have not and will not use an LLM to write any part of this PR description or PR comments.

## Screenshots (if applicable)
<!-- Add screenshots or screen recordings to help the reviewer understand the UI changes. -->

